### PR TITLE
ace-OPENPASS-1923-remove-cloud-secret

### DIFF
--- a/charts/kube-aws/ec2-terminate-by-id/experiment.yaml
+++ b/charts/kube-aws/ec2-terminate-by-id/experiment.yaml
@@ -88,6 +88,4 @@ spec:
       app.kubernetes.io/part-of: litmus
       app.kubernetes.io/component: experiment-job
       app.kubernetes.io/version: latest
-    secrets:
-    - name: cloud-secret
-      mountPath: /tmp/
+

--- a/charts/kube-aws/ec2-terminate-by-tag/experiment.yaml
+++ b/charts/kube-aws/ec2-terminate-by-tag/experiment.yaml
@@ -90,6 +90,4 @@ spec:
       app.kubernetes.io/part-of: litmus
       app.kubernetes.io/component: experiment-job
       app.kubernetes.io/version: latest
-    secrets:
-    - name: cloud-secret
-      mountPath: /tmp/
+


### PR DESCRIPTION
## JIRA Ticket

https://atlassian.thetradedesk.com/jira/browse/OPENPASS-1923

## What does this PR do?

Removes the cloud-secret mount for ec2 termination experiments. This is no longer required because the litmus-admin service account now has an IAM role, allowing the ec2 termination